### PR TITLE
Adds Sentinel Connector Monitor Rules

### DIFF
--- a/Sentinel/MonitorSentinelConnectors.json
+++ b/Sentinel/MonitorSentinelConnectors.json
@@ -1,0 +1,216 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "workspace": {
+            "type": "String"
+        }
+    },
+    "resources": [
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/07f544e9-8b2f-4204-a67f-d71e482cbca7')]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/07f544e9-8b2f-4204-a67f-d71e482cbca7')]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "kind": "Scheduled",
+            "apiVersion": "2021-09-01-preview",
+            "properties": {
+                "displayName": "Monitor Azure Activity (AzureActivity) Sentinel Connector",
+                "description": "This rule actively monitors the Azure Activity Sentinel connector's AzureActivity table. It triggers an alert if there has not been logs generated in the last 72 hours.",
+                "severity": "Medium",
+                "enabled": true,
+                "query": "AzureActivity\r\n| where TimeGenerated > ago(7d)\r\n| summarize lastlog=datetime_diff(\"Hour\", now(), max(TimeGenerated)) by Type\r\n| where lastlog >= 72",
+                "queryFrequency": "P1D",
+                "queryPeriod": "P5D",
+                "triggerOperator": "GreaterThan",
+                "triggerThreshold": 0,
+                "suppressionDuration": "P1D",
+                "suppressionEnabled": true,
+                "tactics": [],
+                "techniques": [],
+                "alertRuleTemplateName": null,
+                "incidentConfiguration": {
+                    "createIncident": true,
+                    "groupingConfiguration": {
+                        "enabled": false,
+                        "reopenClosedIncident": false,
+                        "lookbackDuration": "PT5H",
+                        "matchingMethod": "AllEntities",
+                        "groupByEntities": [],
+                        "groupByAlertDetails": [],
+                        "groupByCustomDetails": []
+                    }
+                },
+                "eventGroupingSettings": {
+                    "aggregationKind": "SingleAlert"
+                },
+                "alertDetailsOverride": null,
+                "customDetails": null,
+                "entityMappings": null
+            }
+        },
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/70d43c39-f2a4-46e8-b27a-d98b4e4e83b1')]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/70d43c39-f2a4-46e8-b27a-d98b4e4e83b1')]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "kind": "Scheduled",
+            "apiVersion": "2021-09-01-preview",
+            "properties": {
+                "displayName": "Monitor Azure AD (AuditLogs) Sentinel Connector",
+                "description": "This rule actively monitors the Azure AD Sentinel connector's AuditLog table. It triggers an alert if there has not been logs generated in the last 72 hours.",
+                "severity": "Medium",
+                "enabled": true,
+                "query": "AuditLogs\r\n| where TimeGenerated > ago(7d)\r\n| summarize lastlog=datetime_diff(\"Hour\", now(), max(TimeGenerated)) by Type\r\n| where lastlog >= 72",
+                "queryFrequency": "P1D",
+                "queryPeriod": "P5D",
+                "triggerOperator": "GreaterThan",
+                "triggerThreshold": 0,
+                "suppressionDuration": "P1D",
+                "suppressionEnabled": true,
+                "tactics": [],
+                "techniques": [],
+                "alertRuleTemplateName": null,
+                "incidentConfiguration": {
+                    "createIncident": true,
+                    "groupingConfiguration": {
+                        "enabled": false,
+                        "reopenClosedIncident": false,
+                        "lookbackDuration": "PT5H",
+                        "matchingMethod": "AllEntities",
+                        "groupByEntities": [],
+                        "groupByAlertDetails": [],
+                        "groupByCustomDetails": []
+                    }
+                },
+                "eventGroupingSettings": {
+                    "aggregationKind": "SingleAlert"
+                },
+                "alertDetailsOverride": null,
+                "customDetails": null,
+                "entityMappings": null
+            }
+        },
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/155bb819-713b-4817-b72b-a01c9665475b')]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/155bb819-713b-4817-b72b-a01c9665475b')]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "kind": "Scheduled",
+            "apiVersion": "2021-09-01-preview",
+            "properties": {
+                "displayName": "Monitor Azure AD (SigninLogs) Sentinel Connector",
+                "description": "This rule actively monitors the Azure AD Sentinel connector's SigninLogs table. It triggers an alert if there has not been logs generated in the last 72 hours.",
+                "severity": "Medium",
+                "enabled": true,
+                "query": "SigninLogs\r\n| where TimeGenerated > ago(7d)\r\n| summarize lastlog=datetime_diff(\"Hour\", now(), max(TimeGenerated)) by Type\r\n| where lastlog >= 72",
+                "queryFrequency": "P1D",
+                "queryPeriod": "P5D",
+                "triggerOperator": "GreaterThan",
+                "triggerThreshold": 0,
+                "suppressionDuration": "P1D",
+                "suppressionEnabled": true,
+                "tactics": [],
+                "techniques": [],
+                "alertRuleTemplateName": null,
+                "incidentConfiguration": {
+                    "createIncident": true,
+                    "groupingConfiguration": {
+                        "enabled": false,
+                        "reopenClosedIncident": false,
+                        "lookbackDuration": "PT5H",
+                        "matchingMethod": "AllEntities",
+                        "groupByEntities": [],
+                        "groupByAlertDetails": [],
+                        "groupByCustomDetails": []
+                    }
+                },
+                "eventGroupingSettings": {
+                    "aggregationKind": "SingleAlert"
+                },
+                "alertDetailsOverride": null,
+                "customDetails": null,
+                "entityMappings": null
+            }
+        },
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/dfbe28a6-565c-4317-af31-f65dfdb23010')]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/dfbe28a6-565c-4317-af31-f65dfdb23010')]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "kind": "Scheduled",
+            "apiVersion": "2021-09-01-preview",
+            "properties": {
+                "displayName": "Monitor Office 365 (OfficeActivity) Connector",
+                "description": "This rule actively monitors the Office365 Sentinel connector's OfficeActivity table. It triggers an alert if there has not been logs generated in the last 72 hours.",
+                "severity": "Medium",
+                "enabled": true,
+                "query": "OfficeActivity\r\n| where TimeGenerated > ago(7d)\r\n| summarize lastlog=datetime_diff(\"Hour\", now(), max(TimeGenerated)) by Type\r\n| where lastlog >= 72",
+                "queryFrequency": "P1D",
+                "queryPeriod": "P5D",
+                "triggerOperator": "GreaterThan",
+                "triggerThreshold": 0,
+                "suppressionDuration": "P1D",
+                "suppressionEnabled": true,
+                "tactics": [],
+                "techniques": [],
+                "alertRuleTemplateName": null,
+                "incidentConfiguration": {
+                    "createIncident": true,
+                    "groupingConfiguration": {
+                        "enabled": false,
+                        "reopenClosedIncident": false,
+                        "lookbackDuration": "PT5H",
+                        "matchingMethod": "AllEntities",
+                        "groupByEntities": [],
+                        "groupByAlertDetails": [],
+                        "groupByCustomDetails": []
+                    }
+                },
+                "eventGroupingSettings": {
+                    "aggregationKind": "SingleAlert"
+                },
+                "alertDetailsOverride": null,
+                "customDetails": null,
+                "entityMappings": null
+            }
+        },
+        {
+            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/a4aca780-3721-4c13-8918-72ff5f4ab54c')]",
+            "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/a4aca780-3721-4c13-8918-72ff5f4ab54c')]",
+            "type": "Microsoft.OperationalInsights/workspaces/providers/alertRules",
+            "kind": "Scheduled",
+            "apiVersion": "2021-09-01-preview",
+            "properties": {
+                "displayName": "Monitor Security Events via Legacy Agent (SecurityEvent) Connector",
+                "description": "This rule actively monitors the Security Events via Legacy Agent Sentinel connector's SecurityEvent table. It triggers an alert if there have not been logs generated in the last 72 hours.",
+                "severity": "Medium",
+                "enabled": true,
+                "query": "SecurityEvent\r\n| where TimeGenerated > ago(7d)\r\n| summarize lastlog=datetime_diff(\"Hour\", now(), max(TimeGenerated)) by Type\r\n| where lastlog >= 72",
+                "queryFrequency": "P1D",
+                "queryPeriod": "P5D",
+                "triggerOperator": "GreaterThan",
+                "triggerThreshold": 0,
+                "suppressionDuration": "P1D",
+                "suppressionEnabled": true,
+                "tactics": [],
+                "techniques": [],
+                "alertRuleTemplateName": null,
+                "incidentConfiguration": {
+                    "createIncident": true,
+                    "groupingConfiguration": {
+                        "enabled": false,
+                        "reopenClosedIncident": false,
+                        "lookbackDuration": "PT5H",
+                        "matchingMethod": "AllEntities",
+                        "groupByEntities": [],
+                        "groupByAlertDetails": [],
+                        "groupByCustomDetails": []
+                    }
+                },
+                "eventGroupingSettings": {
+                    "aggregationKind": "SingleAlert"
+                },
+                "alertDetailsOverride": null,
+                "customDetails": null,
+                "entityMappings": null
+            }
+        }
+    ]
+}

--- a/Sentinel/readme.md
+++ b/Sentinel/readme.md
@@ -1,0 +1,39 @@
+#Overview
+The MonitorSentinelConnectors.json file can be imported to any Sentinel Workspace. Upon being imported, five scheduled query rules will be built that run on a daily interval. The specifics of each are outlined in detail below.
+|Connector|Table Monitoring|Alert Criteria|
+| --- | --- | --- |
+|Azure Activity|AzureActivity|Alert if no logs in past 72 Hours|
+|Azure Active Directory (AuditLogs)|AuditLogs|Alert if no logs in past 72 hours|
+|Azure Active Directory (SigninLogs)|SigninLogs|Alert if no logs in past 72 hours|
+|Office 365|OfficeActivity|Alert if no logs in past 72 hours|
+|Security Events via Legacy Agent|SecurityEvents|Alert if no logs in past 72 hours|
+#Instructions
+1) Log into your Sentinel workspace.
+2) Click on Analytics.
+3) Click on Import.
+4) Import the attached file.
+5) Confirm successful upload by ensuring the scheduled query rules in the table above show. These are listed in the Analytics blade in Sentinel.
+#Logic
+Each rule listed in the table above has a similar query. Below is a simple breakdown.
+##Query Breakdown
+```
+<TableName>
+| where TimeGenerated > ago(7d)
+| summarize lastlog=datetime_diff("Hour", now(), max(TimeGenerated)) by Type
+| where lastlog >= 72
+```
+First, pull in the table we're monitoring.
+Next, filter only logs generated in the past 7 days.
+Then, calculate how many hours it has been since the last log was generated.
+Finally, filter only results where the last log has been more than 72 hours ago.
+##Modification
+If 72 hours does not make sense for your environment, you can modify this setting. In the last line, modify ```72``` to a number that is more appropriate for your environment.  ```| where lastlog >=72```
+> ⚠ If this query is changed to a number greater than 168, ensure you're also modifying the second line of each query to expand the logs being evaluated.
+# License
+[![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License][cc-by-nc-sa].
+[![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
+[cc-by-nc-sa]: http://creativecommons.org/licenses/by-nc-sa/4.0/
+[cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
+[cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg


### PR DESCRIPTION
The MonitorSentinelConnectors.json file can be imported to any Sentinel Workspace. Upon being imported, five scheduled query rules will be built that run on a daily interval.